### PR TITLE
add options to set user and database

### DIFF
--- a/2.6/set_mongodb_password.sh
+++ b/2.6/set_mongodb_password.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+USER=${MONGODB_USER:-"admin"}
+DATABASE=${MONGODB_DATABASE:-"admin"}
 PASS=${MONGODB_PASS:-$(pwgen -s 12 1)}
 _word=$( [ ${MONGODB_PASS} ] && echo "preset" || echo "random" )
 
@@ -11,8 +13,11 @@ while [[ RET -ne 0 ]]; do
     RET=$?
 done
 
-echo "=> Creating an admin user with a ${_word} password in MongoDB"
-mongo admin --eval "db.createUser({user: 'admin', pwd: '$PASS', roles:[{role:'root',db:'admin'}]});"
+echo "=> Creating an ${USER} user with a ${_word} password in MongoDB"
+mongo admin << EOF
+use $DATABASE
+db.createUser({user: '$USER', pwd: '$PASS', roles:[{role:'dbOwner',db:'$DATABASE'}]})
+EOF
 
 echo "=> Done!"
 touch /data/db/.mongodb_password_set
@@ -20,7 +25,7 @@ touch /data/db/.mongodb_password_set
 echo "========================================================================"
 echo "You can now connect to this MongoDB server using:"
 echo ""
-echo "    mongo admin -u admin -p $PASS --host <host> --port <port>"
+echo "    mongo $DATABASE -u $USER -p $PASS --host <host> --port <port>"
 echo ""
 echo "Please remember to change the above password as soon as possible!"
 echo "========================================================================"

--- a/3.0/set_mongodb_password.sh
+++ b/3.0/set_mongodb_password.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+USER=${MONGODB_USER:-"admin"}
+DATABASE=${MONGODB_DATABASE:-"admin"}
 PASS=${MONGODB_PASS:-$(pwgen -s 12 1)}
 _word=$( [ ${MONGODB_PASS} ] && echo "preset" || echo "random" )
 
@@ -11,8 +13,11 @@ while [[ RET -ne 0 ]]; do
     RET=$?
 done
 
-echo "=> Creating an admin user with a ${_word} password in MongoDB"
-mongo admin --eval "db.createUser({user: 'admin', pwd: '$PASS', roles:[{role:'root',db:'admin'}]});"
+echo "=> Creating an ${USER} user with a ${_word} password in MongoDB"
+mongo admin << EOF
+use $DATABASE
+db.createUser({user: '$USER', pwd: '$PASS', roles:[{role:'dbOwner',db:'$DATABASE'}]})
+EOF
 
 echo "=> Done!"
 touch /data/db/.mongodb_password_set
@@ -20,7 +25,7 @@ touch /data/db/.mongodb_password_set
 echo "========================================================================"
 echo "You can now connect to this MongoDB server using:"
 echo ""
-echo "    mongo admin -u admin -p $PASS --host <host> --port <port>"
+echo "    mongo $DATABASE -u $USER -p $PASS --host <host> --port <port>"
 echo ""
 echo "Please remember to change the above password as soon as possible!"
 echo "========================================================================"

--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ You can now test your new admin password:
         mongo admin -u admin -p mypass
         curl --user admin:mypass --digest http://localhost:28017/
 
+
+Setting a specific user:database
+--------------------------------
+
+If you want to use another database with another user
+
+        docker run -d -p 27017:27017 -p 28017:28017 -e MONGODB_USER="user" -e MONGODB_DATABASE="mydatabase" -e MONGODB_PASS="mypass" tutum/mongodb
+
+You can now test your new credentials:
+
+        mongo mydatabase -u user -p mypass
+
 Run MongoDB without password
 ----------------------------
 


### PR DESCRIPTION
### enable to set a specific user:database

If you want to use another database with another user

        docker run -d -p 27017:27017 -p 28017:28017 -e MONGODB_USER="user" -e MONGODB_DATABASE="mydatabase" -e MONGODB_PASS="mypass" tutum/mongodb

You can now test your new credentials:

        mongo mydatabase -u user -p mypass