### PR TITLE
add options to set user and database

### DIFF
--- a/2.6/set_mongodb_password.sh
+++ b/2.6/set_mongodb_password.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+USER=${MONGODB_USER:-"admin"}
+DATABASE=${MONGODB_DATABASE:-"admin"}
 PASS=${MONGODB_PASS:-$(pwgen -s 12 1)}
 _word=$( [ ${MONGODB_PASS} ] && echo "preset" || echo "random" )
 
@@ -11,8 +13,11 @@ while [[ RET -ne 0 ]]; do
     RET=$?
 done
 
-echo "=> Creating an admin user with a ${_word} password in MongoDB"
-mongo admin --eval "db.createUser({user: 'admin', pwd: '$PASS', roles:[{role:'root',db:'admin'}]});"
+echo "=> Creating an ${USER} user with a ${_word} password in MongoDB"
+mongo admin << EOF
+use $DATABASE
+db.createUser({user: '$USER', pwd: '$PASS', roles:[{role:'dbOwner',db:'$DATABASE'}]})
+EOF
 
 echo "=> Done!"
 touch /data/db/.mongodb_password_set
@@ -20,7 +25,7 @@ touch /data/db/.mongodb_password_set
 echo "========================================================================"
 echo "You can now connect to this MongoDB server using:"
 echo ""
-echo "    mongo admin -u admin -p $PASS --host <host> --port <port>"
+echo "    mongo $DATABASE -u $USER -p $PASS --host <host> --port <port>"
 echo ""
 echo "Please remember to change the above password as soon as possible!"
 echo "========================================================================"

--- a/3.0/set_mongodb_password.sh
+++ b/3.0/set_mongodb_password.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+USER=${MONGODB_USER:-"admin"}
+DATABASE=${MONGODB_DATABASE:-"admin"}
 PASS=${MONGODB_PASS:-$(pwgen -s 12 1)}
 _word=$( [ ${MONGODB_PASS} ] && echo "preset" || echo "random" )
 
@@ -11,8 +13,16 @@ while [[ RET -ne 0 ]]; do
     RET=$?
 done
 
-echo "=> Creating an admin user with a ${_word} password in MongoDB"
-mongo admin --eval "db.createUser({user: 'admin', pwd: '$PASS', roles:[{role:'root',db:'admin'}]});"
+echo "=> Creating an ${USER} user with a ${_word} password in MongoDB"
+mongo admin --eval "db.createUser({user: '$USER', pwd: '$PASS', roles:[{role:'root',db:'admin'}]});"
+
+if [ "$DATABASE" != "admin" ]; then
+    echo "=> Creating an ${USER} user with a ${_word} password in MongoDB"
+    mongo admin -u $USER -p $PASS << EOF
+use $DATABASE
+db.createUser({user: '$USER', pwd: '$PASS', roles:[{role:'dbOwner',db:'$DATABASE'}]})
+EOF
+fi
 
 echo "=> Done!"
 touch /data/db/.mongodb_password_set
@@ -20,7 +30,7 @@ touch /data/db/.mongodb_password_set
 echo "========================================================================"
 echo "You can now connect to this MongoDB server using:"
 echo ""
-echo "    mongo admin -u admin -p $PASS --host <host> --port <port>"
+echo "    mongo $DATABASE -u $USER -p $PASS --host <host> --port <port>"
 echo ""
 echo "Please remember to change the above password as soon as possible!"
 echo "========================================================================"

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:14.04
+MAINTAINER Tutum Labs <support@tutum.co>
+
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10 && \
+    echo "deb http://repo.mongodb.org/apt/ubuntu "$(lsb_release -sc)"/mongodb-org/3.2 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.2.list && \
+    apt-get update && \
+    apt-get install -y --force-yes pwgen mongodb-org mongodb-org-server mongodb-org-shell mongodb-org-mongos mongodb-org-tools && \
+    echo "mongodb-org hold" | dpkg --set-selections && echo "mongodb-org-server hold" | dpkg --set-selections && \
+    echo "mongodb-org-shell hold" | dpkg --set-selections && \
+    echo "mongodb-org-mongos hold" | dpkg --set-selections && \
+    echo "mongodb-org-tools hold" | dpkg --set-selections
+
+VOLUME /data/db
+
+ENV AUTH yes
+ENV STORAGE_ENGINE wiredTiger
+ENV JOURNALING yes
+
+ADD run.sh /run.sh
+ADD set_mongodb_password.sh /set_mongodb_password.sh
+
+EXPOSE 27017 28017
+
+CMD ["/run.sh"]

--- a/3.2/run.sh
+++ b/3.2/run.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -m
+
+mongodb_cmd="mongod --storageEngine $STORAGE_ENGINE"
+cmd="$mongodb_cmd --httpinterface --rest --master"
+if [ "$AUTH" == "yes" ]; then
+    cmd="$cmd --auth"
+fi
+
+if [ "$JOURNALING" == "no" ]; then
+    cmd="$cmd --nojournal"
+fi
+
+if [ "$OPLOG_SIZE" != "" ]; then
+    cmd="$cmd --oplogSize $OPLOG_SIZE"
+fi
+
+$cmd &
+
+if [ ! -f /data/db/.mongodb_password_set ]; then
+    /set_mongodb_password.sh
+fi
+
+fg

--- a/3.2/set_mongodb_password.sh
+++ b/3.2/set_mongodb_password.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+USER=${MONGODB_USER:-"admin"}
+DATABASE=${MONGODB_DATABASE:-"admin"}
+PASS=${MONGODB_PASS:-$(pwgen -s 12 1)}
+_word=$( [ ${MONGODB_PASS} ] && echo "preset" || echo "random" )
+
+RET=1
+while [[ RET -ne 0 ]]; do
+    echo "=> Waiting for confirmation of MongoDB service startup"
+    sleep 5
+    mongo admin --eval "help" >/dev/null 2>&1
+    RET=$?
+done
+
+echo "=> Creating an ${USER} user with a ${_word} password in MongoDB"
+mongo admin --eval "db.createUser({user: '$USER', pwd: '$PASS', roles:[{role:'root',db:'admin'}]});"
+
+if [ "$DATABASE" != "admin" ]; then
+    echo "=> Creating an ${USER} user with a ${_word} password in MongoDB"
+    mongo admin -u $USER -p $PASS << EOF
+use $DATABASE
+db.createUser({user: '$USER', pwd: '$PASS', roles:[{role:'dbOwner',db:'$DATABASE'}]})
+EOF
+fi
+
+echo "=> Done!"
+touch /data/db/.mongodb_password_set
+
+echo "========================================================================"
+echo "You can now connect to this MongoDB server using:"
+echo ""
+echo "    mongo $DATABASE -u $USER -p $PASS --host <host> --port <port>"
+echo ""
+echo "Please remember to change the above password as soon as possible!"
+echo "========================================================================"

--- a/README.md
+++ b/README.md
@@ -63,6 +63,22 @@ You can now test your new admin password:
         mongo admin -u admin -p mypass
         curl --user admin:mypass --digest http://localhost:28017/
 
+
+Setting a specific user:database
+--------------------------------
+
+If you want to use another database with another user
+
+    docker run -d -p 27017:27017 -p 28017:28017 -e MONGODB_USER="user" -e MONGODB_DATABASE="mydatabase" -e MONGODB_PASS="mypass" tutum/mongodb
+
+You can now test your new credentials:
+
+    mongo mydatabase -u user -p mypass
+
+Note: with mongo 3.x an admin user is also created with the same credentials
+
+    mongo admin -u user -p mypass
+
 Run MongoDB without password
 ----------------------------
 


### PR DESCRIPTION
### Setting a specific user:database

If you want to use another database with another user

    docker run -d -p 27017:27017 -p 28017:28017 -e MONGODB_USER="user" -e MONGODB_DATABASE="mydatabase" -e MONGODB_PASS="mypass" tutum/mongodb

You can now test your new credentials:

    mongo mydatabase -u user -p mypass

Note: with mongo 3.x an admin user is also created with the same credentials

    mongo admin -u user -p mypass